### PR TITLE
Added support for Django 1.11

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,7 @@
+Change log
+==========
+
+0.7.0
+-----
+
+* Django 1.10 compatibility

--- a/useful/__init__.py
+++ b/useful/__init__.py
@@ -1,2 +1,2 @@
-__version__ = (0, 6, 11)
+__version__ = (0, 7, 0)
 __versionstr__ = '.'.join(map(str, __version__))

--- a/useful/django/remote_addr.py
+++ b/useful/django/remote_addr.py
@@ -1,8 +1,13 @@
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:  # Django < 1.10
+    MiddlewareMixin = object
 
-class SetRemoteAddrMiddleware(object):
+
+class SetRemoteAddrMiddleware(MiddlewareMixin):
     """
     Request middleware that sets REMOTE_ADDR based on request.META variable
     pointed by settings.REAL_IP_META_VARIABLE_NAME.

--- a/useful/django/views.py
+++ b/useful/django/views.py
@@ -2,6 +2,7 @@ import os
 import time
 import functools
 
+import django
 from django.conf import settings
 from django.core.paginator import Paginator, EmptyPage, InvalidPage
 from django.core.urlresolvers import reverse
@@ -68,13 +69,19 @@ def page(template=None, **decorator_args):
                 stn = os.path.splitext(template_name)
                 template_name = stn[0] + '_debug' + stn[1]
 
-            # The view or the decorator call can override the context
-            # instance. Otherwise, use the usual RequestContext.
-            context_instance = data.get('context') or RequestContext(request)
+            if django.VERSION < (1, 10):
+                # The view or the decorator call can override the context
+                # instance. Otherwise, use the usual RequestContext.
+                context_instance = data.get('context') or RequestContext(request)
 
-            # Render the template.
-            response = render_to_response(template_name, data, context_instance)
-            return response
+                # Render the template.
+                response = render_to_response(template_name, data, context_instance)
+                return response
+            return render(
+                request,
+                template_name,
+                context=data
+            )
 
         return page_decorator_inner_wrapper
     return page_decorator_wrapper

--- a/useful/django/views.py
+++ b/useful/django/views.py
@@ -3,10 +3,10 @@ import time
 import functools
 
 import django
+from django import shortcuts
 from django.conf import settings
 from django.core.paginator import Paginator, EmptyPage, InvalidPage
 from django.core.urlresolvers import reverse
-from django.shortcuts import render_to_response
 from django.http import HttpResponse, HttpResponseRedirect, HttpResponseBadRequest
 from django.template import RequestContext
 
@@ -75,9 +75,9 @@ def page(template=None, **decorator_args):
                 context_instance = data.get('context') or RequestContext(request)
 
                 # Render the template.
-                response = render_to_response(template_name, data, context_instance)
+                response = shortcuts.render_to_response(template_name, data, context_instance)
                 return response
-            return render(
+            return shortcuts.render(
                 request,
                 template_name,
                 context=data


### PR DESCRIPTION
Please check the page decorator as there is no Context or RequestContext anymore in common template API (https://docs.djangoproject.com/en/1.11/topics/templates/#context)